### PR TITLE
Add support for negative ranges in classes

### DIFF
--- a/lib/regexp-to-ast.js
+++ b/lib/regexp-to-ast.js
@@ -477,12 +477,12 @@
                         set.push({ from: from.value, to: to.value })
                     } else {
                         // literal dash
-                        insertToSet(from.value, set)
+                        insertToSet(from, set)
                         set.push(cc("-"))
-                        insertToSet(to.value, set)
+                        insertToSet(to, set)
                     }
                 } else {
-                    insertToSet(from.value, set)
+                    insertToSet(from, set)
                 }
             }
 
@@ -818,13 +818,50 @@
             return char.charCodeAt(0)
         }
 
-        function insertToSet(item, set) {
-            if (item.length !== undefined) {
-                item.forEach(function(subItem) {
-                    set.push(subItem)
-                })
-            } else {
-                set.push(item)
+        function invertRanges(ranges) {
+            // clarify the below logic by ensuring we only have to deal
+            // with ranges.
+            var positiveRanges = ranges.map(function(charOrRange) {
+                if (typeof charOrRange === "number") {
+                    return { from: charOrRange, to: charOrRange }
+                } else {
+                    return charOrRange
+                }
+            })
+
+            var from = 0
+            var output = []
+            for (var i = 0; i < positiveRanges.length; i++) {
+                if (positiveRanges[i].from > from) {
+                    output.push({ from: from, to: positiveRanges[i].from - 1 })
+                }
+                from = positiveRanges[i].to + 1
+            }
+
+            if (from <= 0xffff) {
+                output.push({ from: from, to: 0xffff })
+            }
+            return output
+        }
+
+        function insertToSet(node, set) {
+            switch (node.type) {
+                case "Character":
+                    set.push(node.value)
+                break;
+
+                case "Set":
+                    var toInsert = node.value
+                    if (node.complement) {
+                      toInsert = invertRanges(node.value)
+                    }
+                    toInsert.forEach(function(subItem) {
+                        set.push(subItem)
+                    })
+                break;
+
+                default:
+                    throw new Error("TBD")
             }
         }
 

--- a/test/parser_spec.js
+++ b/test/parser_spec.js
@@ -1559,6 +1559,31 @@ describe("The RegExp to Ast parser", () => {
                             ]
                         })
                     })
+
+                    it("inverted digits", () => {
+                        const ast = parser.pattern("/[\\D]/")
+                        expect(ast.value).to.deep.equal({
+                            type: "Disjunction",
+                            loc: { begin: 1, end: 5 },
+                            value: [
+                                {
+                                    type: "Alternative",
+                                    loc: { begin: 1, end: 5 },
+                                    value: [
+                                        {
+                                            type: "Set",
+                                            loc: { begin: 1, end: 5 },
+                                            complement: false,
+                                            value: [
+                                              {from: 0, to: 47},
+                                              {from: 58, to: 0xffff}
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        })
+                    })
                 })
 
                 it("pattern character", () => {


### PR DESCRIPTION
Before this change [\D] was treated the same as [\d] because the
complement flag was lost.

After this change [\D] correctly represents the set of non-\d
characters.

This also enables [\d\D] to match every single character.

Fixes #66