### PR TITLE
Lookbehind assertions

### DIFF
--- a/api.d.ts
+++ b/api.d.ts
@@ -46,6 +46,8 @@ export interface Assertion extends IRegExpAST {
         | "NonWordBoundary"
         | "Lookahead"
         | "NegativeLookahead"
+        | "Lookbehind"
+        | "NegativeLookbehind"
 
     value?: Disjunction
 }
@@ -116,6 +118,8 @@ export class BaseRegExpVisitor {
     visitNonWordBoundary(node: Assertion)
     visitLookahead(node: Assertion)
     visitNegativeLookahead(node: Assertion)
+    visitLookbehind(node: Assertion)
+    visitNegativeLookbehind(node: Assertion)
     visitCharacter(node: Character)
     visitSet(node: Set)
     visitGroup(Node: Group)

--- a/lib/regexp-to-ast.js
+++ b/lib/regexp-to-ast.js
@@ -148,16 +148,13 @@
                     throw Error("Invalid Assertion Escape")
                 // '(?=' or '(?!' or '(<=' or '(<!'
                 case "(":
-                    var directionStr
-                    switch (this.popChar()) {
-                        case "?":
-                            directionStr = "Lookahead"
-                            break
-                        case "<":
-                            directionStr = "Lookbehind"
-                            break
+                    this.consumeChar("?")
+
+                    var directionStr = "Lookahead"
+                    if (this.peekChar(0) === "<") {
+                        this.consumeChar("<")
+                        directionStr = "Lookbehind"
                     }
-                    ASSERT_EXISTS(directionStr)
 
                     var negativeStr
                     switch (this.popChar()) {
@@ -727,11 +724,12 @@
                     }
                 // '(?=' or '(?!' or '(<=' or '(<!'
                 case "(":
-                    return (
-                        (this.peekChar(1) === "?" ||
-                            this.peekChar(1) === "<") &&
-                        (this.peekChar(2) === "=" || this.peekChar(2) === "!")
-                    )
+                    if (this.peekChar(1) !== "?") {
+                        return false
+                    }
+                    var isLookbehind = this.peekChar(2) === "<"
+                    var directionChar = this.peekChar(isLookbehind ? 3 : 2)
+                    return directionChar === "=" || directionChar === "!"
                 default:
                     return false
             }

--- a/lib/regexp-to-ast.js
+++ b/lib/regexp-to-ast.js
@@ -1001,7 +1001,7 @@
 
         BaseRegExpVisitor.prototype.visitNegativeLookahead = function(node) {}
 
-        BaseRegExpVisitor.prototype.visitLookBehind = function(node) {}
+        BaseRegExpVisitor.prototype.visitLookbehind = function(node) {}
 
         BaseRegExpVisitor.prototype.visitNegativeLookbehind = function(node) {}
 

--- a/lib/regexp-to-ast.js
+++ b/lib/regexp-to-ast.js
@@ -146,20 +146,30 @@
                     }
                     // istanbul ignore next
                     throw Error("Invalid Assertion Escape")
-                // '(?=' or '(?!'
+                // '(?=' or '(?!' or '(<=' or '(<!'
                 case "(":
-                    this.consumeChar("?")
-
-                    var type
+                    var directionStr
                     switch (this.popChar()) {
-                        case "=":
-                            type = "Lookahead"
+                        case "?":
+                            directionStr = "Lookahead"
                             break
-                        case "!":
-                            type = "NegativeLookahead"
+                        case "<":
+                            directionStr = "Lookbehind"
                             break
                     }
-                    ASSERT_EXISTS(type)
+                    ASSERT_EXISTS(directionStr)
+
+                    var negativeStr
+                    switch (this.popChar()) {
+                        case "=":
+                            negativeStr = ""
+                            break
+                        case "!":
+                            negativeStr = "Negative"
+                            break
+                    }
+                    ASSERT_EXISTS(negativeStr)
+                    var type = negativeStr + directionStr
 
                     var disjunction = this.disjunction()
 
@@ -715,10 +725,11 @@
                         default:
                             return false
                     }
-                // '(?=' or '(?!'
+                // '(?=' or '(?!' or '(<=' or '(<!'
                 case "(":
                     return (
-                        this.peekChar(1) === "?" &&
+                        (this.peekChar(1) === "?" ||
+                            this.peekChar(1) === "<") &&
                         (this.peekChar(2) === "=" || this.peekChar(2) === "!")
                     )
                 default:
@@ -943,6 +954,12 @@
                 case "NegativeLookahead":
                     this.visitNegativeLookahead(node)
                     break
+                case "Lookbehind":
+                    this.visitLookbehind(node)
+                    break
+                case "NegativeLookbehind":
+                    this.visitNegativeLookbehind(node)
+                    break
                 case "Character":
                     this.visitCharacter(node)
                     break
@@ -983,6 +1000,10 @@
         BaseRegExpVisitor.prototype.visitLookahead = function(node) {}
 
         BaseRegExpVisitor.prototype.visitNegativeLookahead = function(node) {}
+
+        BaseRegExpVisitor.prototype.visitLookBehind = function(node) {}
+
+        BaseRegExpVisitor.prototype.visitNegativeLookbehind = function(node) {}
 
         // atoms
         BaseRegExpVisitor.prototype.visitCharacter = function(node) {}

--- a/test/parser_spec.js
+++ b/test/parser_spec.js
@@ -468,14 +468,14 @@ describe("The RegExp to Ast parser", () => {
                 })
             })
             it("lookbehind assertion", () => {
-                const ast = parser.pattern("/a(<=b)/")
+                const ast = parser.pattern("/a(?<=b)/")
                 expect(ast.value).to.deep.equal({
                     type: "Disjunction",
-                    loc: { begin: 1, end: 7 },
+                    loc: { begin: 1, end: 8 },
                     value: [
                         {
                             type: "Alternative",
-                            loc: { begin: 1, end: 7 },
+                            loc: { begin: 1, end: 8 },
                             value: [
                                 {
                                     type: "Character",
@@ -484,20 +484,20 @@ describe("The RegExp to Ast parser", () => {
                                 },
                                 {
                                     type: "Lookbehind",
-                                    loc: { begin: 2, end: 7 },
+                                    loc: { begin: 2, end: 8 },
                                     value: {
                                         type: "Disjunction",
-                                        loc: { begin: 5, end: 6 },
+                                        loc: { begin: 6, end: 7 },
                                         value: [
                                             {
                                                 type: "Alternative",
-                                                loc: { begin: 5, end: 6 },
+                                                loc: { begin: 6, end: 7 },
                                                 value: [
                                                     {
                                                         type: "Character",
                                                         loc: {
-                                                            begin: 5,
-                                                            end: 6
+                                                            begin: 6,
+                                                            end: 7
                                                         },
                                                         value: 98
                                                     }
@@ -513,14 +513,14 @@ describe("The RegExp to Ast parser", () => {
             })
 
             it("lookbehind assertion", () => {
-                const ast = parser.pattern("/a(<!b)/")
+                const ast = parser.pattern("/a(?<!b)/")
                 expect(ast.value).to.deep.equal({
                     type: "Disjunction",
-                    loc: { begin: 1, end: 7 },
+                    loc: { begin: 1, end: 8 },
                     value: [
                         {
                             type: "Alternative",
-                            loc: { begin: 1, end: 7 },
+                            loc: { begin: 1, end: 8 },
                             value: [
                                 {
                                     type: "Character",
@@ -529,20 +529,20 @@ describe("The RegExp to Ast parser", () => {
                                 },
                                 {
                                     type: "NegativeLookbehind",
-                                    loc: { begin: 2, end: 7 },
+                                    loc: { begin: 2, end: 8 },
                                     value: {
                                         type: "Disjunction",
-                                        loc: { begin: 5, end: 6 },
+                                        loc: { begin: 6, end: 7 },
                                         value: [
                                             {
                                                 type: "Alternative",
-                                                loc: { begin: 5, end: 6 },
+                                                loc: { begin: 6, end: 7 },
                                                 value: [
                                                     {
                                                         type: "Character",
                                                         loc: {
-                                                            begin: 5,
-                                                            end: 6
+                                                            begin: 6,
+                                                            end: 7
                                                         },
                                                         value: 98
                                                     }

--- a/test/parser_spec.js
+++ b/test/parser_spec.js
@@ -467,6 +467,95 @@ describe("The RegExp to Ast parser", () => {
                     ]
                 })
             })
+            it("lookbehind assertion", () => {
+                const ast = parser.pattern("/a(<=b)/")
+                expect(ast.value).to.deep.equal({
+                    type: "Disjunction",
+                    loc: { begin: 1, end: 7 },
+                    value: [
+                        {
+                            type: "Alternative",
+                            loc: { begin: 1, end: 7 },
+                            value: [
+                                {
+                                    type: "Character",
+                                    loc: { begin: 1, end: 2 },
+                                    value: 97
+                                },
+                                {
+                                    type: "Lookbehind",
+                                    loc: { begin: 2, end: 7 },
+                                    value: {
+                                        type: "Disjunction",
+                                        loc: { begin: 5, end: 6 },
+                                        value: [
+                                            {
+                                                type: "Alternative",
+                                                loc: { begin: 5, end: 6 },
+                                                value: [
+                                                    {
+                                                        type: "Character",
+                                                        loc: {
+                                                            begin: 5,
+                                                            end: 6
+                                                        },
+                                                        value: 98
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                })
+            })
+
+            it("lookbehind assertion", () => {
+                const ast = parser.pattern("/a(<!b)/")
+                expect(ast.value).to.deep.equal({
+                    type: "Disjunction",
+                    loc: { begin: 1, end: 7 },
+                    value: [
+                        {
+                            type: "Alternative",
+                            loc: { begin: 1, end: 7 },
+                            value: [
+                                {
+                                    type: "Character",
+                                    loc: { begin: 1, end: 2 },
+                                    value: 97
+                                },
+                                {
+                                    type: "NegativeLookbehind",
+                                    loc: { begin: 2, end: 7 },
+                                    value: {
+                                        type: "Disjunction",
+                                        loc: { begin: 5, end: 6 },
+                                        value: [
+                                            {
+                                                type: "Alternative",
+                                                loc: { begin: 5, end: 6 },
+                                                value: [
+                                                    {
+                                                        type: "Character",
+                                                        loc: {
+                                                            begin: 5,
+                                                            end: 6
+                                                        },
+                                                        value: 98
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                })
+            })
         })
 
         context("quantifiers", () => {

--- a/test/visitor_spec.js
+++ b/test/visitor_spec.js
@@ -126,6 +126,30 @@ describe("The regexp AST visitor", () => {
         new NegativeLookaheadVisitor().visit(ast)
     })
 
+    it("Can visit Lookbehind", () => {
+        const ast = parser.pattern("/a(<=a|b)/")
+        class LookbehindVisitor extends BaseRegExpVisitor {
+            visitLookbehind(node) {
+                super.visitLookbehind(node)
+                expect(node.value.value).to.have.lengthOf(2)
+            }
+        }
+
+        new LookbehindVisitor().visit(ast)
+    })
+
+    it("Can visit NegativeLookbehind", () => {
+        const ast = parser.pattern("/a(<!a|b|c)/")
+        class NegativeLookbehindVisitor extends BaseRegExpVisitor {
+            visitNegativeLookbehind(node) {
+                super.visitNegativeLookbehind(node)
+                expect(node.value.value).to.have.lengthOf(3)
+            }
+        }
+
+        new NegativeLookbehindVisitor().visit(ast)
+    })
+
     it("Can visit Character", () => {
         const ast = parser.pattern("/a/")
         class CharacterVisitor extends BaseRegExpVisitor {

--- a/test/visitor_spec.js
+++ b/test/visitor_spec.js
@@ -127,7 +127,7 @@ describe("The regexp AST visitor", () => {
     })
 
     it("Can visit Lookbehind", () => {
-        const ast = parser.pattern("/a(<=a|b)/")
+        const ast = parser.pattern("/a(?<=a|b)/")
         class LookbehindVisitor extends BaseRegExpVisitor {
             visitLookbehind(node) {
                 super.visitLookbehind(node)
@@ -139,7 +139,7 @@ describe("The regexp AST visitor", () => {
     })
 
     it("Can visit NegativeLookbehind", () => {
-        const ast = parser.pattern("/a(<!a|b|c)/")
+        const ast = parser.pattern("/a(?<!a|b|c)/")
         class NegativeLookbehindVisitor extends BaseRegExpVisitor {
             visitNegativeLookbehind(node) {
                 super.visitNegativeLookbehind(node)


### PR DESCRIPTION
It was an almost copy paste from the lookahead assertions

This would fix https://github.com/bd82/regexp-to-ast/issues/27